### PR TITLE
Development

### DIFF
--- a/Choix_Recommandations.md
+++ b/Choix_Recommandations.md
@@ -1,0 +1,139 @@
+# Choix des Recommandations
+
+Le choix des groupes de recommandations (ou "guidance groups" en anglais) se faisait précédemment dans l'onglet Informations Générales. Il se fait désormais dans l'onglet Rédiger.
+
+## Affichage & Comportement
+
+Voir maquette "4_1 OPIDoR - Page principale rédaction avec onglets"
+
+On affiche un collapse, fermé par défaut, avec une icône d'ampoule qui est identique à celui présent au niveau des questions.
+Libellés :
+
+- *fr_FR* : Sélectionnez les recommandations de votre plan
+- *en_GB* : Select the guidance of your plan
+
+L'ouverture du collapse de sélection des recommandations déclenche l'appel au serveur qui permet de récupérer la liste des demandes, si celles ci ne sont pas déjà présentes dans le Context.
+A l'ouverture, on affiche les recommandations importantes, un bouton Voir plus permet d'afficher l'ensemble des recommandations disponibles dans l'application. Une case à cocher permet d'indiquer si des recommandations ont été sélectionnées. On peut en sélectionner 6 au maximum.
+Pour chaque organisme ayant des recommandations, on affiche les groupes disponibles en dessous (voir capture tache Kanboard : https://kb.inist.fr/project/265/task/8695)
+
+Lorsque l'on valide son choix, on met à jour la liste des recommandations liées au question,  en rechargeant les composants par exemple.
+L'icône d'ampoule présente au niveau des questions doit indiquer que des recommandations liées à la question sont disponibles.
+
+## Données
+
+### Chargement des recommandations
+
+A l'ouverture du collapse, appel à la route `GET /plans/:id/guidance_groups`
+
+- id ou planId: identifiant du plan donc l'onglet Rédiger est actuellement ouvert
+
+Renvoit un objet JSON contenant :
+
+- la liste de tous les groupes de recommandations `all` => affichés lorsque l'on clique sur Voir tout
+- la liste des groupes de recommandations importants `important` => affichés lors de l'ouverture du collapse
+- la liste des groupes de recommandations selectionés `selected` => affichés lors de l'ouverture du collapse en plus des recommandations importantes
+
+Chacun de ces tableaux peut être vide.
+
+```json
+{
+    "all" : {
+        "Digital Curation Centre": [
+            {
+            "id": 27,
+            "name": "DCC",
+            "org_id": 7
+            }
+        ],
+        "INRAE - Institut national de recherche pour l'agriculture l'alimentation et l'environnement": [
+            {
+            "id": 28,
+            "name": "INRA",
+            "org_id": 5
+            },
+            {
+            "id": 41,
+            "name": "INRA GenoBois",
+            "org_id": 5
+            }
+        ],
+        "CIRAD": [
+            {
+            "id": 29,
+            "name": "Guidance groupe CIRAD",
+            "org_id": 17
+            }
+        ]
+    },
+    "important": {
+        "INRAE - Institut national de recherche pour l'agriculture l'alimentation et l'environnement": [
+            {
+            "id": 28,
+            "name": "INRA",
+            "org_id": 5
+            },
+            {
+            "id": 41,
+            "name": "INRA GenoBois",
+            "org_id": 5
+            }
+        ]
+    }, 
+    "selected": [
+        28
+    ]
+}
+```
+
+Description des données:
+
+- all/important : objet dont les clés sont les noms des organismes auquel sont liés les recommandations. Chacun de ces clés pointe sur un tableau des groupes de recommandations
+  
+  - id: identifiant du groupe de recommandations
+  - name: nom du groupe de recommandations
+  - org_id : identifiant de l'organimse lié au groupe de recommandations
+- selected : tableau contenant les identifiants des groupes de recommandations sélectionnés.
+
+### Enregistrement du choix des recommandations
+
+Lorsque l'on appuie sur le bouton Valider du choix des recommandations
+Appel à la route `POST /plans/:id/guidance_groups`
+
+- id ou planId: identifiant du plan donc l'onglet Rédiger est actuellement ouvert
+
+#### Données du body
+
+```json
+[27, 29, 31]
+```
+
+Un tableau contenant les idenfitiants des groupes de recommandations sélectionnés.
+
+#### Données en réponse
+
+```json
+[30661, 30663]
+```
+
+Un tableau contenant la liste des identifiants des questions (questionId) possédant des recommandations. Cette liste permet d'ajouter ou de retirer l'icone indiquant la présence de recommandation au niveau de la question (icone Ampoule)
+
+### Chargement de l'onglet Rédiger : nouvelles données
+
+De nouvelles données sont à prendre en compte lors du chargement de l'onglet Rédiger
+
+```json
+{
+    "plan": {
+        "id": 1234,
+        "dmp_id": 9876,
+        "research_outputs": [(...)],
+        "questions_with_guidance": [
+            30671, 12347
+        ]
+    }
+}
+```
+
+Description des nouvelles données :
+
+- questions_with_guidance : tableau des identifiants des questions (questionId) possédant des recommandations. Cette liste permet d'afficher ou non l'icone indiquant la présence de recommandation au niveau de la question (icone Ampoule)

--- a/Retours_Onglet_Informations_Generales.md
+++ b/Retours_Onglet_Informations_Generales.md
@@ -1,0 +1,26 @@
+# Retours Onglet Information Générale
+
+## Fonctionnement de l'Onglet
+
+Par défaut les formulaires Projet et Meta sont affichés. L'import d'informations projet venant d'un financeur est facultatif. Il faut donc afficher l'onglet Projet avec le template ProjectStandard. L'import d'information financeur permet seulement de remplir automatiquement le formulaire projet et n'est pas nécessaire à l'affichage du formulaire.
+
+## Affichage de l'onglet
+
+L'import est fermé par défaut
+Les formulaires Projet et Meta sont ouverts par défaut.
+Le contenu de l'onglet peut s'afficher si il n'existe aucun organisme de financement (`dataFundingOrganization`). On pourrait cependant n'afficher le panel "Import Financeur" que si `dataFundingOrganization` existe.
+
+## Variables & fonctions à renommer
+
+- `isOpenPlan, setIsOpenPlan` => `isOpenMetaForm, setIsOpenMetaForm`
+- `isOpenProject, setIsOpenProject` => `isOpenProjectForm, setIsOpenProjectForm`
+- `isOpenFunder, setIsOpenFunder` => `isOpenFunderImport, setIsOpenFunderImport`
+- `isOpenFunder, setIsOpenFunder` => `isOpenFunderImport, setIsOpenFunderImport`
+- `dataFundingOrganization, setDataFundingOrganization` => `funders, setFunders`
+- `fundedProject, setFundedProject` => `fundedProjects, setFundedProjects`
+
+- `getFundingOrganization` => `getFunders`
+- `getFundedProject` => `getFundedProjects`
+- `handleChangeFunder` => `handleSelectFunder`
+- `handleSaveFunder` => `handleSaveFunding`
+- `saveFunder` => `saveFunding`

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -88,5 +88,7 @@
   "Plan Information": "Renseignements sur le plan",
   "Click here if you have a funded project": "Cliquez ici si vous avez un projet financé",
   "You cannot delete the first element": "vous ne pouvez pas supprimer le premier élément",
-  "Selected value": "Valeur sélectionnée"
+  "Selected value": "Valeur sélectionnée",
+  "Save my choise": "Enregistrer mon choix",
+  "To help you write your plan, DMP OPIDoR offers you recommendations from different organizations - you can select up to 6 organizations.": " Pour vous aider à rédiger votre plan, DMP OPIDoR vous propose des recommandations provenant de différents organismes - vous pouvez sélectionner jusqu’à 6 organismes."
 }

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -90,5 +90,6 @@
   "You cannot delete the first element": "vous ne pouvez pas supprimer le premier élément",
   "Selected value": "Valeur sélectionnée",
   "Save my choise": "Enregistrer mon choix",
+  "Select the guidance of your plan": "Sélectionnez les recommandations de votre plan",
   "To help you write your plan, DMP OPIDoR offers you recommendations from different organizations - you can select up to 6 organizations.": " Pour vous aider à rédiger votre plan, DMP OPIDoR vous propose des recommandations provenant de différents organismes - vous pouvez sélectionner jusqu’à 6 organismes."
 }

--- a/src/App.css
+++ b/src/App.css
@@ -14,3 +14,10 @@ a:hover {
 a:active {
   text-decoration: none;
 }
+
+.checkbox-custom-label {
+  position: relative;
+  padding-left: 35px;
+  cursor: pointer;
+  display: inline-block;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,7 @@ import Form from "./components/Forms/Form";
 import PlanCreation from "./components/PlanCreation/PlanCreation";
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import WritePlanLayout from "./components/WritePlan/WritePlanLayout";
-import GeneralInfoLayout from "./components/GeneralInfo/GeneralInfoLayout";
+import GeneralInfo from "./components/GeneralInfo/GeneralInfo";
 
 function App() {
   return (
@@ -13,7 +13,7 @@ function App() {
         <Route exact path="/redaction" element={<WritePlanLayout />} />
         <Route exact path="/form" element={<Form schemaId={"a"} />} />
         <Route exact path="/plan" element={<PlanCreation />} />
-        <Route exact path="/" element={<GeneralInfoLayout />} />
+        <Route exact path="/" element={<GeneralInfo />} />
       </Routes>
     </Router>
   );

--- a/src/components/GeneralInfo/GeneralInfo.jsx
+++ b/src/components/GeneralInfo/GeneralInfo.jsx
@@ -118,7 +118,6 @@ function GeneralInfo() {
                     <div className={styles.question_text}>
                       <div className={styles.title_anr}>{t("Click here if you have a funded project")}</div>
                     </div>
-
                     <span className={styles.question_icons}>
                       {/* 3 */}
                       {isOpenFunderImport ? (
@@ -179,7 +178,13 @@ function GeneralInfo() {
               </Panel.Body>
             </Panel>
           </PanelGroup>
-          <PanelGroup accordion id="accordion-example" className={styles.panel} onClick={() => setIsOpenProjectForm(!isOpenProjectForm)}>
+          <PanelGroup
+            accordion
+            id="accordion-example"
+            className={styles.panel}
+            onClick={() => setIsOpenProjectForm(!isOpenProjectForm)}
+            defaultActiveKey="2"
+          >
             <Panel eventKey={"2"} style={{ borderRadius: "10px", borderWidth: "2px", borderColor: "var(--primary)" }}>
               <Panel.Heading style={{ background: "white", borderRadius: "18px" }}>
                 <Panel.Title toggle>
@@ -192,18 +197,24 @@ function GeneralInfo() {
                       {/* 3 */}
 
                       {isOpenProjectForm ? (
-                        <TfiAngleDown style={{ minWidth: "35px" }} size={35} className={styles.down_icon} />
-                      ) : (
                         <TfiAngleUp style={{ minWidth: "35px" }} size={35} className={styles.down_icon} />
+                      ) : (
+                        <TfiAngleDown style={{ minWidth: "35px" }} size={35} className={styles.down_icon} />
                       )}
                     </span>
                   </div>
                 </Panel.Title>
               </Panel.Heading>
-              <Panel.Body collapsible={true}>{true && <Form schemaId={"ProjectStandard"}></Form>}</Panel.Body>
+              <Panel.Body collapsible>{true && <Form schemaId={"ProjectStandard"}></Form>}</Panel.Body>
             </Panel>
           </PanelGroup>
-          <PanelGroup accordion id="accordion-example" className={styles.panel} onClick={() => setIsOpenMetaForm(!isOpenMetaForm)}>
+          <PanelGroup
+            accordion
+            id="accordion-example"
+            className={styles.panel}
+            onClick={() => setIsOpenMetaForm(!isOpenMetaForm)}
+            defaultActiveKey="3"
+          >
             <Panel eventKey={"3"} style={{ borderRadius: "10px", borderWidth: "2px", borderColor: "var(--primary)" }}>
               <Panel.Heading style={{ background: "white", borderRadius: "18px" }}>
                 <Panel.Title toggle>
@@ -215,9 +226,9 @@ function GeneralInfo() {
                     <span className={styles.question_icons}>
                       {/* 3 */}
                       {isOpenMetaForm ? (
-                        <TfiAngleDown style={{ minWidth: "35px" }} size={35} className={styles.down_icon} />
-                      ) : (
                         <TfiAngleUp style={{ minWidth: "35px" }} size={35} className={styles.down_icon} />
+                      ) : (
+                        <TfiAngleDown style={{ minWidth: "35px" }} size={35} className={styles.down_icon} />
                       )}
                     </span>
                   </div>

--- a/src/components/GeneralInfo/GeneralInfo.jsx
+++ b/src/components/GeneralInfo/GeneralInfo.jsx
@@ -14,7 +14,7 @@ import Select from "react-select";
 import styled from "styled-components";
 import { useEffect } from "react";
 import { BiInfoCircle } from "react-icons/bi";
-import { getFundedProject, getFundingOrganization, saveFunder } from "../../services/DmpGeneralInfoApi";
+import { getFundedProjects, getFunders, getFundingOrganization, saveFunder } from "../../services/DmpGeneralInfoApi";
 import Form from "../Forms/Form";
 
 export const ButtonSave = styled.button`
@@ -26,37 +26,39 @@ export const ButtonSave = styled.button`
   border-radius: 8px !important;
 `;
 
-function GeneralInfoLayout() {
+function GeneralInfo() {
   const { t, i18n } = useTranslation();
   const [lng] = useState(i18n.language.split("-")[0]);
-  const [dataFundingOrganization, setDataFundingOrganization] = useState([]);
+  const [funders, setFunders] = useState([]);
   const [fundedProject, setFundedProject] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
-  const [isOpenFunder, setIsOpenFunder] = useState(false);
-  const [isOpenProject, setIsOpenProject] = useState(true);
-  const [isOpenPlan, setIsOpenPlan] = useState(true);
+
+  const [isOpenFunderImport, setIsOpenFunderImport] = useState(false);
+  const [isOpenProjectForm, setIsOpenProjectForm] = useState(true);
+  const [isOpenMetaForm, setIsOpenMetaForm] = useState(true);
   const [grantId, setGrantId] = useState(null);
   const [projectFragmentId, setProjectFragmentId] = useState("1");
 
   /* This `useEffect` hook is fetching data for funding organizations and setting the options for a `Select` component. It runs only once when the
-component mounts, as the dependency array `[]` is empty. */
+  component mounts, as the dependency array `[]` is empty. */
   useEffect(() => {
-    getFundingOrganization().then((res) => {
+    getFunders().then((res) => {
       const options = res.data.map((option) => ({
         value: option.id,
         label: option.name,
       }));
-      setDataFundingOrganization(options);
+      setFunders(options);
     });
   }, []);
+
   /* This `useEffect` hook is fetching data for funded projects and setting the options for a `Select` component. It runs only once when the component
-mounts, as the dependency array `[]` is empty. It sets the loading state to `true` before making the API call, and then sets it to `false` after the
-API call is completed, regardless of whether it was successful or not. If there is an error during the API call, it sets the error state to the error
-object. */
+  mounts, as the dependency array `[]` is empty. It sets the loading state to `true` before making the API call, and then sets it to `false` after the
+  API call is completed, regardless of whether it was successful or not. If there is an error during the API call, it sets the error state to the error
+  object. */
   useEffect(() => {
     setLoading(true);
-    getFundedProject()
+    getFundedProjects()
       .then((res) => {
         const options = res.data["ANRProjects"].map((option) => ({
           value: option.value,
@@ -71,7 +73,7 @@ object. */
   /**
    * The function logs the value of an event and sets a grant ID to "ProjectStandard".
    */
-  const handleChangeFunder = (e) => {
+  const handleSelectFunder = (e) => {
     console.log(e.value);
     //setGrantId("ProjectStandard");
   };
@@ -79,7 +81,7 @@ object. */
   /**
    * The function `handleSaveFunder` saves a funder for a project fragment and sets the grant ID to "ProjectStandard".
    */
-  const handleSaveFunder = () => {
+  const handleSaveFunding = () => {
     saveFunder(grantId, projectFragmentId).then((res) => {
       console.log(res);
       setGrantId("ProjectStandard");
@@ -93,9 +95,15 @@ object. */
       <Navbar></Navbar>
       {loading && <CustomSpinner></CustomSpinner>}
       {!loading && error && <CustomError></CustomError>}
-      {!loading && !error && dataFundingOrganization && (
+      {!loading && !error && funders && (
         <div className="container">
-          <PanelGroup accordion id="accordion-example" className={styles.panel} onClick={() => setIsOpenFunder(!isOpenFunder)} defaultActiveKey="1">
+          <PanelGroup
+            accordion
+            id="accordion-example"
+            className={styles.panel}
+            onClick={() => setIsOpenFunderImport(!isOpenFunderImport)}
+            defaultActiveKey="1"
+          >
             <Panel
               eventKey={"1"}
               style={{
@@ -113,7 +121,7 @@ object. */
 
                     <span className={styles.question_icons}>
                       {/* 3 */}
-                      {isOpenFunder ? (
+                      {isOpenFunderImport ? (
                         <TfiAngleDown style={{ minWidth: "35px" }} size={35} className={styles.down_icon_anr} onClick={(e) => {}} />
                       ) : (
                         <TfiAngleUp style={{ minWidth: "35px" }} size={35} className={styles.down_icon_anr} onClick={(e) => {}} />
@@ -141,7 +149,7 @@ object. */
                           singleValue: (base) => ({ ...base, color: "var(--primary)" }),
                           control: (base) => ({ ...base, borderRadius: "8px", borderWidth: "1px", borderColor: "var(--primary)" }),
                         }}
-                        options={dataFundingOrganization}
+                        options={funders}
                       />
                     )}
                   </div>
@@ -160,18 +168,18 @@ object. */
                         }}
                         options={fundedProject}
                         style={{ color: "red" }}
-                        onChange={(e) => handleChangeFunder(e)}
+                        onChange={(e) => handleSelectFunder(e)}
                       />
                     )}
                   </div>
-                  <ButtonSave className="btn btn-light" onClick={handleSaveFunder}>
+                  <ButtonSave className="btn btn-light" onClick={handleSaveFunding}>
                     {t("Save")}
                   </ButtonSave>
                 </div>
               </Panel.Body>
             </Panel>
           </PanelGroup>
-          <PanelGroup accordion id="accordion-example" className={styles.panel} onClick={() => setIsOpenProject(!isOpenProject)}>
+          <PanelGroup accordion id="accordion-example" className={styles.panel} onClick={() => setIsOpenProjectForm(!isOpenProjectForm)}>
             <Panel eventKey={"2"} style={{ borderRadius: "10px", borderWidth: "2px", borderColor: "var(--primary)" }}>
               <Panel.Heading style={{ background: "white", borderRadius: "18px" }}>
                 <Panel.Title toggle>
@@ -183,7 +191,7 @@ object. */
                     <span className={styles.question_icons}>
                       {/* 3 */}
 
-                      {isOpenProject ? (
+                      {isOpenProjectForm ? (
                         <TfiAngleDown style={{ minWidth: "35px" }} size={35} className={styles.down_icon} />
                       ) : (
                         <TfiAngleUp style={{ minWidth: "35px" }} size={35} className={styles.down_icon} />
@@ -192,10 +200,10 @@ object. */
                   </div>
                 </Panel.Title>
               </Panel.Heading>
-              <Panel.Body collapsible={true}>{grantId && <Form schemaId={grantId}></Form>}</Panel.Body>
+              <Panel.Body collapsible={true}>{true && <Form schemaId={"ProjectStandard"}></Form>}</Panel.Body>
             </Panel>
           </PanelGroup>
-          <PanelGroup accordion id="accordion-example" className={styles.panel} onClick={() => setIsOpenPlan(!isOpenPlan)}>
+          <PanelGroup accordion id="accordion-example" className={styles.panel} onClick={() => setIsOpenMetaForm(!isOpenMetaForm)}>
             <Panel eventKey={"3"} style={{ borderRadius: "10px", borderWidth: "2px", borderColor: "var(--primary)" }}>
               <Panel.Heading style={{ background: "white", borderRadius: "18px" }}>
                 <Panel.Title toggle>
@@ -206,7 +214,7 @@ object. */
 
                     <span className={styles.question_icons}>
                       {/* 3 */}
-                      {isOpenPlan ? (
+                      {isOpenMetaForm ? (
                         <TfiAngleDown style={{ minWidth: "35px" }} size={35} className={styles.down_icon} />
                       ) : (
                         <TfiAngleUp style={{ minWidth: "35px" }} size={35} className={styles.down_icon} />
@@ -218,7 +226,7 @@ object. */
               <Panel.Body collapsible={true}>
                 {projectFragmentId && (
                   <>
-                    <div className="container" style={{ display: "flex", justifyContent: "end", marginLeft: "-110px" }}>
+                    <div className="container" style={{ display: "flex", justifyContent: "end", margin: "20px 0px 0px -110px " }}>
                       <div className="form-check form-switch">
                         <input
                           className="form-check-input"
@@ -246,4 +254,4 @@ object. */
   );
 }
 
-export default GeneralInfoLayout;
+export default GeneralInfo;

--- a/src/components/GeneralInfo/GeneralInfoLayout.jsx
+++ b/src/components/GeneralInfo/GeneralInfoLayout.jsx
@@ -215,7 +215,28 @@ object. */
                   </div>
                 </Panel.Title>
               </Panel.Heading>
-              <Panel.Body collapsible={true}>{projectFragmentId && <Form schemaId={"MetaStandard"}></Form>}</Panel.Body>
+              <Panel.Body collapsible={true}>
+                {projectFragmentId && (
+                  <>
+                    <div className="container" style={{ display: "flex", justifyContent: "end", marginLeft: "-110px" }}>
+                      <div className="form-check form-switch">
+                        <input
+                          className="form-check-input"
+                          type="checkbox"
+                          id="flexSwitchCheckDefault"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                          }}
+                        />
+                        <label className="form-check-label" htmlFor="flexSwitchCheckDefault">
+                          Plan de test
+                        </label>
+                      </div>
+                    </div>
+                    <Form schemaId={"MetaStandard"}></Form>
+                  </>
+                )}
+              </Panel.Body>
             </Panel>
           </PanelGroup>
         </div>

--- a/src/components/ResearchOutput/ResearchOutputModal.jsx
+++ b/src/components/ResearchOutput/ResearchOutputModal.jsx
@@ -15,9 +15,9 @@ function ResearchOutputModal({ planId, handleClose, show }) {
 
   return (
     <Modal show={show} onHide={handleClose}>
-      <Modal.Header closeButton>
+      {/* <Modal.Header closeButton>
         <Modal.Title>{t("Research Product")}</Modal.Title>
-      </Modal.Header>
+      </Modal.Header> */}
       <Modal.Body style={{ padding: "20px !important" }}>
         <div className={`col-md-12 ${styles.funder}`}>
           <fieldset className="sub-fragment registry">

--- a/src/components/Shared/Navbar.jsx
+++ b/src/components/Shared/Navbar.jsx
@@ -18,7 +18,7 @@ function Navbar() {
   // A map of paths to tab indices:
   const pathMap = {
     "/": 0,
-    "/redaction": 2,
+    "/redaction": 1,
   };
 
   /* This code is using the `useEffect` hook to update the active tab in the navbar based on the current path in the URL. It listens for changes to the
@@ -33,7 +33,6 @@ specific paths to tab indices, so that the correct tab is highlighted when the u
     <ul id="plan_navigation" className={`nav nav-tabs ${styles.plan_navigation}`} role="tablist">
       {[
         { to: "/", svg: <InfoSVG />, text: t("Informations générales") },
-        { to: "#", svg: <ReasearchSVG />, text: t("Research products") },
         { to: "/redaction", svg: <RedactionSVG />, text: t("Redact") },
         { to: "#", svg: <ContributorSVG />, text: t("Contributors") },
         { to: "#", svg: <BudgetSVG />, text: t("Budget") },

--- a/src/components/WritePlan/GuidanceModal.jsx
+++ b/src/components/WritePlan/GuidanceModal.jsx
@@ -1,6 +1,6 @@
 import DOMPurify from "dompurify";
 import React, { useEffect, useState } from "react";
-import { getRecommandation } from "../../services/DmpRecommandationApi";
+import { getGuidance } from "../../services/DmpGuidanceApi";
 import CustomError from "../Shared/CustomError";
 import CustomSpinner from "../Shared/CustomSpinner";
 import { NavBody, NavBodyText, ScrollNav, MainNav, Close, Theme } from "./styles/GuidanceModalStyles";
@@ -52,7 +52,7 @@ function GuidanceModal({ show, setshowModalRecommandation, setFillColorIconRecom
   /* A hook that is called when the component is mounted. */
   useEffect(() => {
     setLoading(true);
-    getRecommandation(questionId, "")
+    getGuidance(questionId, "")
       .then((res) => {
         setData(res.data);
       })

--- a/src/components/WritePlan/Recommandation.jsx
+++ b/src/components/WritePlan/Recommandation.jsx
@@ -1,0 +1,140 @@
+import React, { useContext, useEffect, useState } from "react";
+import { Panel, PanelGroup } from "react-bootstrap";
+import { TfiAngleDown } from "react-icons/tfi";
+import { TfiAngleUp } from "react-icons/tfi";
+import styles from "../assets/css/redactions.module.css";
+import LightSVG from "../Styled/svg/LightSVG";
+import stylesRecomandation from "../assets/css/recommandation.module.css";
+import { getRecommendation } from "../../services/DmpRecommandationApi";
+import CustomSpinner from "../Shared/CustomSpinner";
+import CustomError from "../Shared/CustomError";
+import CustomButton from "../Styled/CustomButton";
+import { useTranslation } from "react-i18next";
+
+const pannelTitle = {
+  margin: "0px !important",
+  fontSize: "18px",
+  fontWeight: "bold",
+  marginRight: "60px",
+  fontFamily: "custumHelveticaLight",
+};
+
+const questionText = {
+  display: "flex",
+  fontFamily: "custumHelveticaBold",
+  fontSize: "29px",
+  alignItems: "center",
+};
+
+const questionTitle = {
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  color: "var(--primary)",
+};
+
+const pannelStyle = {
+  margin: "10px",
+  backgroundColor: "var(--white)",
+  fontSize: "large",
+  borderRadius: "20px",
+  boxShadow: "5px 5px 5px #e5e4e7",
+};
+
+function Recommandation({ planId }) {
+  const { t } = useTranslation();
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [checkboxStates, setCheckboxStates] = useState({});
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    setLoading(true);
+    getRecommendation(planId)
+      .then((res) => {
+        setData(res.data);
+      })
+      .catch((error) => setError(error))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleCheckboxChange = (key) => {
+    setCheckboxStates((prevStates) => ({
+      ...prevStates,
+      [key]: !prevStates[key],
+    }));
+  };
+
+  const handleSaveChoise = {};
+
+  return (
+    <PanelGroup accordion id="accordion-example">
+      <Panel eventKey="1" style={pannelStyle}>
+        <Panel.Heading style={{ background: "white", borderRadius: "18px" }}>
+          <Panel.Title toggle onClick={(e) => setIsOpen(!isOpen)}>
+            <div style={questionTitle}>
+              <div style={questionText}>
+                <div>
+                  <LightSVG
+                    fill={"var(--orange)"}
+                    style={{ minWidth: "35px" }}
+                    size={35}
+                    className={styles.down_icon}
+                    onClick={(e) => console.log("z")}
+                  />
+                </div>
+                <div style={pannelTitle} />
+                Sélectionnez vos recommandations du plan
+                <span className={styles.question_icons}>
+                  {isOpen ? (
+                    <TfiAngleUp style={{ minWidth: "35px" }} size={35} className={styles.down_icon} onClick={(e) => console.log("z")} />
+                  ) : (
+                    <TfiAngleDown size={35} style={{ minWidth: "35px" }} className={styles.down_icon} onClick={(e) => console.log("z")} />
+                  )}
+                </span>
+              </div>
+            </div>
+          </Panel.Title>
+        </Panel.Heading>
+        {true && (
+          <Panel.Body collapsible>
+            <div style={{ margin: "10px 180px 0px 180px" }}>
+              <div>
+                {t(
+                  "To help you write your plan, DMP OPIDoR offers you recommendations from different organizations - you can select up to 6 organizations."
+                )}
+              </div>
+              {loading && <CustomSpinner></CustomSpinner>}
+              {!loading && error && <CustomError></CustomError>}
+              {!loading && !error && data && (
+                <div className="container" style={{ margin: "20px" }}>
+                  {Object.keys(data.all).map((key, index) => (
+                    <div key={index} className="form-check" style={{ margin: "5px" }}>
+                      <input
+                        className="form-check-input"
+                        type="checkbox"
+                        checked={checkboxStates[key] || false}
+                        onChange={() => handleCheckboxChange(key)}
+                        id={`flexCheck${index}`}
+                      />
+                      <label
+                        className={`${stylesRecomandation.label_checkbox} ${checkboxStates[key] ? stylesRecomandation.checked : ""}`}
+                        htmlFor={`flexCheck${index}`}
+                      >
+                        {key}
+                      </label>
+                    </div>
+                  ))}
+                </div>
+              )}
+              <CustomButton title={t("Save my choise")} type="oorange" position="start" onClick={handleSaveChoise}></CustomButton>
+            </div>
+          </Panel.Body>
+        )}
+      </Panel>
+    </PanelGroup>
+  );
+}
+
+export default Recommandation;

--- a/src/components/WritePlan/RunsModal.jsx
+++ b/src/components/WritePlan/RunsModal.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { getRecommandation } from "../../services/DmpRecommandationApi";
+import { getGuidance } from "../../services/DmpGuidanceApi";
 import CustomError from "../Shared/CustomError";
 import CustomSpinner from "../Shared/CustomSpinner";
 import { NavBody, NavBodyText, Description, MainNav, Close, ButtonComment, Title } from "./styles/RunsModalStyles";
@@ -29,7 +29,7 @@ function ModalRuns({ show, setshowModalRuns, setFillColorIconRuns }) {
   /* A hook that is called when the component is mounted. */
   useEffect(() => {
     setLoading(true);
-    getRecommandation("", "")
+    getGuidance("", "")
       .then((res) => {
         setData(res.data);
       })

--- a/src/components/WritePlan/WritePlan.jsx
+++ b/src/components/WritePlan/WritePlan.jsx
@@ -39,6 +39,7 @@ function WritePlan({ researchOutputId, planId, hasPersonnelData }) {
   const [data, setData] = useState(null);
   const [searchProduct, setSearchProduct] = useState(null);
   const [showProductInfo, setShowProductInfo] = useState(false);
+  const [questionGuidance, setQuestionGuidance] = useState([]);
 
   /* A useEffect hook that is called when the component is mounted. It is calling the getQuestion function, which is an async function that returns a
 promise. When the promise is resolved, it sets the data state to the result of the promise. It then sets the initialCollapse state to the result of
@@ -48,10 +49,12 @@ Finally, it sets the loading state to false. */
     setLoading(true);
     getQuestion("token")
       .then((res) => {
+        console.log(res);
         const searchProductFilter = res.data.plan.research_outputs.filter((el) => {
           return el.id === researchOutputId;
         });
         setSearchProduct(searchProductFilter[0]);
+        setQuestionGuidance(res?.data?.plan.questions_with_guidance || []);
         setInitialData(res.data);
         const result = res.data.sections;
         setData(result);
@@ -344,21 +347,25 @@ Finally, it sets the loading state to false. */
                                         ></CommentModal>
                                       )}
                                     {/* 2 */}
-                                    <div
-                                      data-tooltip-id="guidanceTip"
-                                      className={styles.panel_icon}
-                                      onClick={(e) => {
-                                        handleShowRecommandationClick(e, isCollapsed?.[researchOutputId]?.[idx]?.[i], q);
-                                      }}
-                                    >
-                                      <LightSVG
-                                        fill={
-                                          isCollapsed?.[researchOutputId]?.[idx]?.[i] === false && questionId && questionId === q.id
-                                            ? fillColorIconRecommandation
-                                            : "var(--primary)"
-                                        }
-                                      />
-                                    </div>
+
+                                    {questionGuidance && questionGuidance.includes(q.id) && (
+                                      <div
+                                        data-tooltip-id="guidanceTip"
+                                        className={styles.panel_icon}
+                                        onClick={(e) => {
+                                          handleShowRecommandationClick(e, isCollapsed?.[researchOutputId]?.[idx]?.[i], q);
+                                        }}
+                                      >
+                                        <LightSVG
+                                          fill={
+                                            isCollapsed?.[researchOutputId]?.[idx]?.[i] === false && questionId && questionId === q.id
+                                              ? fillColorIconRecommandation
+                                              : "var(--primary)"
+                                          }
+                                        />
+                                      </div>
+                                    )}
+
                                     <ReactTooltip id="guidanceTip" place="bottom" effect="solid" variant="info" content={t("Recommandation")} />
                                     {isCollapsed?.[researchOutputId]?.[idx]?.[i] === false &&
                                       showModalRecommandation &&
@@ -371,7 +378,6 @@ Finally, it sets the loading state to false. */
                                           questionId={questionId}
                                         ></GuidanceModal>
                                       )}
-
                                     {/* 3 */}
                                     {isCollapsed?.[researchOutputId]?.[idx]?.[i] ? (
                                       <TfiAngleDown

--- a/src/components/WritePlan/WritePlanLayout.jsx
+++ b/src/components/WritePlan/WritePlanLayout.jsx
@@ -36,6 +36,7 @@ function WritePlanLayout() {
   const [show, setShow] = useState(false);
   const [hasPersonnelData, setHasPersonnelData] = useState(null);
   const [isCollapsed, setIsCollapsed] = useState(null);
+  const [triggerRender, setTriggerRender] = useState(0);
 
   /**
    * The function handleClose sets the state of setShow to false.
@@ -117,7 +118,7 @@ function WritePlanLayout() {
         <>
           <ResearchOutputModal planId={planId}></ResearchOutputModal>
           <div className="container">
-            <Recommandation />
+            <Recommandation planId={planId} setTriggerRender={setTriggerRender} />
           </div>
           <div className={styles.section}>
             <StyledNavBar className="navbar-inverse">
@@ -228,7 +229,12 @@ function WritePlanLayout() {
             {show && <ResearchOutputModal planId={planId} handleClose={handleClose} show={show}></ResearchOutputModal>}
             <div className={styles.main}>
               {researchOutputId && planId && (
-                <WritePlan key={renderKey} researchOutputId={researchOutputId} planId={planId} hasPersonnelData={hasPersonnelData}></WritePlan>
+                <WritePlan
+                  key={renderKey + triggerRender}
+                  researchOutputId={researchOutputId}
+                  planId={planId}
+                  hasPersonnelData={hasPersonnelData}
+                ></WritePlan>
               )}
             </div>
           </div>

--- a/src/components/WritePlan/WritePlanLayout.jsx
+++ b/src/components/WritePlan/WritePlanLayout.jsx
@@ -21,6 +21,7 @@ import ResearchOutputModal from "../ResearchOutput/ResearchOutputModal";
 import { Panel, PanelGroup } from "react-bootstrap";
 import { createDynamicObject, roundedUpDivision } from "../../utils/GeneratorUtils";
 import { useTranslation } from "react-i18next";
+import Recommandation from "./Recommandation";
 
 function WritePlanLayout() {
   const { t } = useTranslation();
@@ -115,6 +116,9 @@ function WritePlanLayout() {
       {!loading && !error && productData && (
         <>
           <ResearchOutputModal planId={planId}></ResearchOutputModal>
+          <div className="container">
+            <Recommandation />
+          </div>
           <div className={styles.section}>
             <StyledNavBar className="navbar-inverse">
               <div className="">
@@ -221,9 +225,7 @@ function WritePlanLayout() {
                 </div>
               </div>
             </StyledNavBar>
-
             {show && <ResearchOutputModal planId={planId} handleClose={handleClose} show={show}></ResearchOutputModal>}
-
             <div className={styles.main}>
               {researchOutputId && planId && (
                 <WritePlan key={renderKey} researchOutputId={researchOutputId} planId={planId} hasPersonnelData={hasPersonnelData}></WritePlan>

--- a/src/components/assets/css/recommandation.module.css
+++ b/src/components/assets/css/recommandation.module.css
@@ -1,0 +1,16 @@
+.label_checkbox {
+  border-radius: 10px;
+  border: solid;
+  border-color: grey;
+  border-width: 1px;
+  margin: 1px 1px 1px 10px;
+  padding: 5px;
+  font-family: custumHelveticaLight;
+  color: var(--primary);
+  font-size: 16px;
+}
+
+.label_checkbox.checked {
+  color: white;
+  background-color: var(--primary);
+}

--- a/src/services/DmpGeneralInfoApi.js
+++ b/src/services/DmpGeneralInfoApi.js
@@ -15,7 +15,7 @@ const dataFundingOrganization = [
  * usually obtained after the user logs in and is used to verify the user's identity for subsequent requests.
  * @returns An object with a "data" property that contains the value of the "dataComent" variable.
  */
-export async function getFundingOrganization(token) {
+export async function getFunders(token) {
   try {
     //const response = await axios.get("note/");
     //return response;
@@ -26,10 +26,10 @@ export async function getFundingOrganization(token) {
 }
 /**
  * The function retrieves data on funded projects from a JSON file or API endpoint using an authentication token.
- * @param token - The `token` parameter is not used in the `getFundedProject` function. It is not necessary for the function to work properly.
+ * @param token - The `token` parameter is not used in the `getFundedProjects` function. It is not necessary for the function to work properly.
  * @returns an object with a `data` property that contains the response from the `ANRProjects.json` file.
  */
-export async function getFundedProject(token) {
+export async function getFundedProjects(token) {
   try {
     //const response = await axios.get("note/");
     //return response;

--- a/src/services/DmpGuidanceApi.js
+++ b/src/services/DmpGuidanceApi.js
@@ -1,17 +1,8 @@
-import React from "react";
-import { render, fireEvent, act, screen } from "@testing-library/react";
-import GuidanceModal from "../components/WritePlan/GuidanceModal";
-import { getGuidance } from "../services/DmpGuidanceApi";
+import axios from "axios";
 
-// Mock the getGuidance function from DmpGuidanceApi
-jest.mock("../services/DmpGuidanceApi", () => ({
-  getGuidance: jest.fn(),
-}));
-
-const sampleData = [
+const dataRecommendation = [
   {
     name: "Science Europe",
-    groups: {},
     annotations: [
       {
         id: 30869,
@@ -116,71 +107,20 @@ const sampleData = [
   },
 ];
 
-describe("ModalRecommandation component", () => {
-  beforeEach(() => {
-    getGuidance.mockImplementation(() => Promise.resolve({ data: sampleData }));
-  });
-
-  it("renders the component and fetches data", async () => {
-    const setShowModalRecommandation = jest.fn();
-    const setFillColorIconRecommandation = jest.fn();
-    render(
-      <GuidanceModal
-        show={true}
-        setshowModalRecommandation={setShowModalRecommandation}
-        setFillColorIconRecommandation={setFillColorIconRecommandation}
-      />
-    );
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-
-    // Expect tabs to be rendered with fetched data
-    expect(screen.getByText("Science Europe")).toBeInTheDocument();
-    expect(screen.getByText("CNRS")).toBeInTheDocument();
-  });
-
-  it("switches between tabs and displays content correctly", async () => {
-    const setShowModalRecommandation = jest.fn();
-    const setFillColorIconRecommandation = jest.fn();
-    render(
-      <GuidanceModal
-        show={true}
-        setshowModalRecommandation={setShowModalRecommandation}
-        setFillColorIconRecommandation={setFillColorIconRecommandation}
-      />
-    );
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-
-    fireEvent.click(screen.getByText("CNRS"));
-    // Expect the content of the active tab to be displayed
-    //expect(screen.getByText("<p>Afin de faciliter l'accessibilit&eacute; aux donn&eacute;es, il est recommand&eacute; d'attribuer des identifiants uniques et p&eacute;rennes.</p>")).toBeInTheDocument();
-    //expect(screen.queryByText("<p>Description g&eacute;n&eacute;rale du produit de recherche</p>")).not.toBeInTheDocument();
-    fireEvent.click(screen.getByText("Science Europe"));
-    // Expect the content of the active tab to be displayed
-    expect(screen.getByText("Description générale du produit de recherche")).toBeInTheDocument();
-    // expect(screen.queryByText("Sample description for Horizon Europe")).not.toBeInTheDocument();
-  });
-
-  it("closes the modal when clicking the close button", async () => {
-    const setShowModalRecommandation = jest.fn();
-    const setFillColorIconRecommandation = jest.fn();
-    render(
-      <GuidanceModal
-        show={true}
-        setshowModalRecommandation={setShowModalRecommandation}
-        setFillColorIconRecommandation={setFillColorIconRecommandation}
-      />
-    );
-
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-
-    fireEvent.click(screen.getByText("x"));
-    expect(setShowModalRecommandation).toHaveBeenCalledWith(false);
-    expect(setFillColorIconRecommandation).toHaveBeenCalledWith("var(--primary)");
-  });
-});
+/**
+ * This function retrieves recommendations for a given question ID and token.
+ * @param questionId - The ID of the question for which the recommendation is being requested.
+ * @param token - The `token` parameter is likely an authentication token or access token that is used to authenticate the user making the API request.
+ * It is usually passed in the headers of the HTTP request to the API server.
+ * @returns An object with a "data" property that contains the data for the recommendation. The actual data is not shown in the code snippet, but it is
+ * likely stored in the "dataRecommendation" variable.
+ */
+export async function getGuidance(questionId, token) {
+  try {
+    //const response = await axios.get(`/questions/${questionId}/guidances`);
+    //return response;
+    return { data: dataRecommendation };
+  } catch (error) {
+    console.error(error);
+  }
+}

--- a/src/services/DmpRecommandationApi.js
+++ b/src/services/DmpRecommandationApi.js
@@ -63,3 +63,15 @@ export async function getRecommendation(planId) {
     console.error(error);
   }
 }
+
+export async function postRecommandation(jsonObject, planId) {
+  try {
+    //const response = await axios.post(`/plans/${planId}/guidance_groups`, jsonObject, "config");
+    return {
+      data: [30661, 30663],
+    };
+  } catch (error) {
+    console.log(error);
+    return error;
+  }
+}

--- a/src/services/DmpRecommandationApi.js
+++ b/src/services/DmpRecommandationApi.js
@@ -1,111 +1,50 @@
 import axios from "axios";
 
-const dataRecommendation = [
-  {
-    name: "Science Europe",
-    annotations: [
+const dataRecommendation = {
+  all: {
+    "Digital Curation Centre": [
       {
-        id: 30869,
-        text: "<p>Description g&eacute;n&eacute;rale du produit de recherche</p>",
+        id: 27,
+        name: "DCC",
+        org_id: 7,
+      },
+    ],
+    "INRAE - Institut national de recherche pour l'agriculture l'alimentation et l'environnement": [
+      {
+        id: 28,
+        name: "INRA",
+        org_id: 5,
+      },
+      {
+        id: 41,
+        name: "INRA GenoBois",
+        org_id: 5,
+      },
+    ],
+    CIRAD: [
+      {
+        id: 29,
+        name: "Guidance groupe CIRAD",
+        org_id: 17,
       },
     ],
   },
-  {
-    name: "CNRS",
-    groups: [
+  important: {
+    "INRAE - Institut national de recherche pour l'agriculture l'alimentation et l'environnement": [
       {
-        theme: "Data description",
-        guidances: [
-          {
-            id: 96,
-            text: "<p>Afin de faciliter l'accessibilit&eacute; aux donn&eacute;es, il est recommand&eacute; d'attribuer des identifiants uniques et p&eacute;rennes.</p>",
-          },
-          {
-            id: 91,
-            text: "<p>Afin de faciliter la recherche de vos donn&eacute;es, utilisez une nomenclature explicite (ex: nom du projet_param&egrave;tre_date de version)</p>",
-          },
-          {
-            id: 92,
-            text: "<p>Pr&eacute;f&eacute;rer les formats non propri&eacute;taires ou largement utilis&eacute;s par votre communaut&eacute;</p>",
-          },
-          {
-            id: 93,
-            text: "<p>Un stockage des donn&eacute;es centralis&eacute; avec acc&egrave;s s&eacute;curis&eacute; et sauvegarde est recommand&eacute;. Les donn&eacute;es d'observation seront stock&eacute;es sur OTELo cloud.</p>",
-          },
-          {
-            id: 94,
-            text: '<p>Vous pouvez utiliser le template (<a href="https://labs.core-cloud.net/ou/OTELo/UMS3562/Lists/DocumentsPartagesSLSSites/Caneva_Metadonnees_donnees.csv" target="_blank">https://labs.core-cloud.net/ou/OTELo/UMS3562/Lists/DocumentsPartagesSLSSites/Caneva_Metadonnees_donnees.csv</a>) mis &agrave; votre disposition qui permettent de d&eacute;crire vos donn&eacute;es sous un format compatible avec les standards EML, INSPIRE, ISO19115.<br />Pour les jeux de donn&eacute;es qui seront partag&eacute;es dans un entrep&ocirc;t, des standards de m&eacute;tadonn&eacute;es sont utilis&eacute;s.</p>',
-          },
-          {
-            id: 80,
-            text: "<p>Bref descriptif</p>",
-          },
-          {
-            id: 81,
-            text: "<p><em>Identifiant de la personne</em> : IdHAL, Researcher ID, ORCID Id <br />L'identifiant ORCID est actuellement encourag&eacute; car c'est un identifiant p&eacute;renne global (multiusages) et unique qui vous permettra de vous connecter &agrave; de nombreuses applications et d'agr&eacute;ger toute votre production scientifique (publication, jeux de donn&eacute;es, logiciels, mod&egrave;les, ...) .</p>",
-          },
-          {
-            id: 82,
-            text: "<p>Personne qui assure le suivi, la mise &agrave; jour et la mise en &oelig;uvre du DMP</p>",
-          },
-          {
-            id: 83,
-            text: "<p>Politique(s) de donn&eacute;es du financeur, institution, laboratoire, discipline, ...</p>",
-          },
-          {
-            id: 84,
-            text: "<p>D&eacute;crire la m&eacute;thode ou citer la r&eacute;f&eacute;rence sans oublier son identifiant (ex DOI, Handle)</p>",
-          },
-          {
-            id: 85,
-            text: "<p>L&rsquo;identification et la description de vos &eacute;chantillons faciliteront leur r&eacute;utilisation et l&rsquo;analyse crois&eacute;e de donn&eacute;es produites par vous-m&ecirc;me ou par diff&eacute;rentes personnes &agrave; partir d&rsquo;un m&ecirc;me &eacute;chantillon. Pour cela, il s&rsquo;agit de convenir d&rsquo;une nomenclature, ce qu&rsquo;on appelle convention de nommage.</p>",
-          },
-          {
-            id: 86,
-            text: "<p>Lieu et conditions de stockage</p>",
-          },
-          {
-            id: 87,
-            text: "<p>Rechercher s'il existe des jeux de donn&eacute;es r&eacute;utilisables dans DataCite, Pangaea, &hellip;.<br />V&eacute;rifier les licences, conditions de r&eacute;utilisation . Citer les jeux de donn&eacute;es r&eacute;utilis&eacute;s par le biais de leurs identifiants</p>",
-          },
-          {
-            id: 88,
-            text: "<p>V&eacute;rifier les licences, conditions de r&eacute;utilisation. Citer les par le biais des identifiants si disponibles</p>",
-          },
-          {
-            id: 90,
-            text: "<p>D&eacute;crire succinctement les m&eacute;thodes de collecte et traitement, analyse des donn&eacute;es. Pr&eacute;ciser les standards, contr&ocirc;les qualit&eacute;s appliqu&eacute;s.</p>",
-          },
-          {
-            id: 95,
-            text: '<p>Par exemple, un dictionnaire des jeux de donn&eacute;es sous format tabulaire afin de pr&eacute;ciser les noms des variables, leurs unit&eacute;s, d&eacute;finitions (Guide de bonnes pratiques, <a href="https://hal.archives-ouvertes.fr/hal-01275841/document" target="_blank">https://hal.archives-ouvertes.fr/hal-01275841/document</a>), des m&eacute;thodes/protocoles, logiciels utilis&eacute;s (nom, version), le mod&egrave;le d\'une base de donn&eacute;es. <strong>Ne pas h&eacute;siter &agrave; mettre en lien les fichiers de documentation associ&eacute;e.</strong></p>',
-          },
-          {
-            id: 97,
-            text: '<p>Ces informations sont pr&eacute;sentes dans l\'accord de consortium s\'il en existe un sinon il faut les pr&eacute;ciser. <br />Indiquer s\'il y a des restrictions au partage des donn&eacute;s par exemple pour des raisons de confidentialit&eacute;&hellip;. (cf Guide Inra : <a href="http://prodinra.inra.fr/?locale=fr#!ConsultNotice:382263" target="_blank">http://prodinra.inra.fr/?locale=fr#!ConsultNotice:382263</a>)</p>',
-          },
-          {
-            id: 98,
-            text: "<p>Par exemple : <br />donn&eacute;es personnelles: d&eacute;claration CNIL/lien, anonymisation<br />esp&egrave;ces prot&eacute;g&eacute;es: acc&egrave;s restreint</p>",
-          },
-          {
-            id: 99,
-            text: "<p>Existe-t-il des entrep&ocirc;ts disciplinaires dans lesquels vous pouvez d&eacute;poser les jeux de donn&eacute;es? Existe-t-il un entrep&ocirc;t institutionnel ou sp&eacute;cifique au projet?</p>",
-          },
-          {
-            id: 100,
-            text: "<p>Le co&ucirc;t de gestion peut inclure les logiciels, l' espace de stockage, les ressources humaines, des formations, &hellip;.</p>",
-          },
-          {
-            id: 101,
-            text: "<p>Estimer le volume en MB, GB, TB.</p>",
-          },
-        ],
+        id: 28,
+        name: "INRA",
+        org_id: 5,
+      },
+      {
+        id: 41,
+        name: "INRA GenoBois",
+        org_id: 5,
       },
     ],
-    annotations: [],
   },
-];
+  selected: [28],
+};
 
 /**
  * This function retrieves recommendations for a given question ID and token.
@@ -115,9 +54,9 @@ const dataRecommendation = [
  * @returns An object with a "data" property that contains the data for the recommendation. The actual data is not shown in the code snippet, but it is
  * likely stored in the "dataRecommendation" variable.
  */
-export async function getRecommandation(questionId, token) {
+export async function getRecommendation(planId) {
   try {
-    //const response = await axios.get(`/questions/${questionId}/guidances`);
+    //const response = await axios.get(`/plans/:${planId}/guidance_groups`);
     //return response;
     return { data: dataRecommendation };
   } catch (error) {

--- a/src/services/DmpRedactionApi.js
+++ b/src/services/DmpRedactionApi.js
@@ -240,6 +240,7 @@ const dataObject = {
         },
       },
     ],
+    questions_with_guidance: [30661, 30662],
   },
 };
 


### PR DESCRIPTION
This Pull Request encompasses several changes regarding the selection of guidance groups, as well as their display and behavior within the application.

We now display a collapsed section by default, with an idea lightbulb icon, identical to the one found next to the questions. When the collapsed section for selecting guidance groups is opened, a call to the server is triggered to fetch the list of requests, if not already present in the Context.

Upon opening, important guidance groups are displayed with a 'See more' button to show all available guidance groups. A checkbox is used to indicate if any guidance groups have been selected. A maximum of six can be selected.

When the selection is validated, the list of recommendations related to the question is updated, by reloading the components for instance. The lightbulb icon next to the questions should indicate that there are recommendations linked to the question.

Data Handling:

Loading of Recommendations: On opening of the collapsed section, a GET request is sent to the /plans/:id/guidance_groups route. This returns a JSON object containing three arrays: 'all', 'important', and 'selected' guidance groups. Each of these arrays can be empty.

Saving the Choice of Recommendations: When the 'Validate' button is pressed, a POST request is sent to the /plans/:id/guidance_groups route with the selected guidance group IDs. The response includes a list of question IDs having recommendations.

